### PR TITLE
Moved profile options to installation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,15 +14,7 @@
 * [Other command line parameters](#other-command-line-parameters)
 * [Adjustable parameters for nf-core/eager](#adjustable-parameters-for-nf-coreeager)
 
-## General Nextflow info
-Nextflow handles job submissions on SLURM or other environments, and supervises running the jobs. Thus the Nextflow process must run until the pipeline is finished. We recommend that you put the process running in the background through `screen` / `tmux` or similar tool. Alternatively you can run nextflow within a cluster job submitted your job scheduler.
-
-It is recommended to limit the Nextflow Java virtual machines memory. We recommend adding the following line to your environment (typically in `~/.bashrc` or `~./bash_profile`):
-
-```bash
-NXF_OPTS='-Xms1g -Xmx4g'
-```
-
+## Preamble
 To access the nextflow help message run: `nextflow run -help`
 
 ## Running the pipeline


### PR DESCRIPTION
Moved bash profile config to installation section.

The bash variable stuff should be set by system administrators setting up nextflow on their system for everyone to use (assuming there is is a centralised computing service), and also a single user setting this up themselves would have to read installation anyway.

Having this here would confuse/scare off bioinformatics novices.

Many thanks to contributing to nf-core/eager!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] If necessary, also make a PR on the [nf-core/eager branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/eager)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [x] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [x] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/eager/tree/master/.github/CONTRIBUTING.md
